### PR TITLE
Add module map.

### DIFF
--- a/Rdio.framework/Modules/module.modulemap
+++ b/Rdio.framework/Modules/module.modulemap
@@ -1,0 +1,4 @@
+framework module Rdio {
+    umbrella header "Rdio.h"
+    export *
+}


### PR DESCRIPTION
This is required in order to `import Rdio` in a Swift file.
